### PR TITLE
feat: add portfolio stats 2025 page

### DIFF
--- a/app/milind-wrapped-2025/page.tsx
+++ b/app/milind-wrapped-2025/page.tsx
@@ -1,0 +1,422 @@
+import {
+  BarChart3Icon,
+  Code2Icon,
+  FileTextIcon,
+  FlameIcon,
+  GitCommitIcon,
+  KeyboardIcon,
+  MusicIcon,
+  PaletteIcon,
+  RocketIcon,
+  SparklesIcon,
+  TrophyIcon,
+} from 'lucide-react';
+import type { Metadata } from 'next';
+import { Section } from '@/components/section';
+import { WRAPPED_2025_STATS, WRAPPED_HIGHLIGHTS } from '@/lib/data/wrapped';
+import { createMetadata } from '@/lib/metadata';
+import { cn } from '@/lib/utils';
+
+export const metadata: Metadata = createMetadata({
+  title: 'Milind Wrapped 2025',
+  description: 'A year in review of Milind Mishra coding journey in 2025',
+  image: `/og?title=${encodeURIComponent('Milind Wrapped 2025')}&description=${encodeURIComponent('A year in review of 2025')}`,
+});
+
+const WITTY_MESSSAGES = [
+  {
+    title: 'Code Commit Champion',
+    message: 'More commits than some people have thoughts in a day!',
+  },
+  {
+    title: 'Feature Factory',
+    message: "Shipping features like it's a pizza delivery service.",
+  },
+  {
+    title: 'Bug Slayer',
+    message: 'Fixing bugs with surgical precision (and some duct tape).',
+  },
+  {
+    title: 'Full Stack Warrior',
+    message: "Frontend, backend, database - you name it, I've done it.",
+  },
+];
+
+function getHighlightIcon(iconName: string) {
+  switch (iconName) {
+    case 'palette':
+      return PaletteIcon;
+    case 'keyboard':
+      return KeyboardIcon;
+    case 'music':
+      return MusicIcon;
+    case 'chart':
+      return BarChart3Icon;
+    case 'file':
+      return FileTextIcon;
+    case 'sparkles':
+      return SparklesIcon;
+    default:
+      return SparklesIcon;
+  }
+}
+
+function StatCard({
+  icon: Icon,
+  title,
+  value,
+  description,
+  delay,
+  className,
+}: {
+  icon: React.ElementType;
+  title: string;
+  value: string | number;
+  description: string;
+  delay?: number;
+  className?: string;
+}) {
+  return (
+    <Section className={cn('flex h-full flex-col', className)} delay={delay}>
+      <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6 transition-colors hover:bg-accent/5">
+        <div className="mb-3 flex shrink-0 items-start justify-between">
+          <Icon className="h-5 w-5 text-muted-foreground" />
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
+            <Icon className="h-4 w-4 text-primary" />
+          </div>
+        </div>
+        <h3 className="shrink-0 font-medium text-foreground-lighter text-xs uppercase tracking-wider">
+          {title}
+        </h3>
+        <div className="mt-2 flex shrink-0 items-baseline gap-2">
+          <p className="font-bold text-3xl text-foreground">{value}</p>
+        </div>
+        <p className="mt-1 text-muted-foreground text-xs">{description}</p>
+      </div>
+    </Section>
+  );
+}
+
+function CommitTypeBar({
+  type,
+  count,
+  total,
+  color,
+  delay,
+}: {
+  type: string;
+  count: number;
+  total: number;
+  color: string;
+  delay?: number;
+}) {
+  const percentage = ((count / total) * 100).toFixed(1);
+
+  return (
+    <Section className="space-y-2" delay={delay}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className={cn('h-3 w-3 rounded-full', color)} />
+          <span className="font-medium text-foreground text-sm capitalize">
+            {type}
+          </span>
+        </div>
+        <span className="text-muted-foreground text-sm">{count} commits</span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-500',
+            color
+          )}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <p className="text-muted-foreground text-xs">{percentage}% of total</p>
+    </Section>
+  );
+}
+
+function MonthBar({
+  month,
+  count,
+  maxCount,
+  delay,
+}: {
+  month: string;
+  count: number;
+  maxCount: number;
+  delay?: number;
+}) {
+  const height =
+    maxCount > 0 ? Math.max(Math.round((count / maxCount) * 100), 5) : 5;
+
+  return (
+    <Section className="flex flex-col items-center gap-2" delay={delay}>
+      <div className="flex h-40 w-full items-end justify-center">
+        <div
+          className="w-full max-w-[3rem] rounded-t-lg bg-primary transition-all duration-500 hover:bg-primary/80"
+          style={{ height: `${height}%` }}
+        />
+      </div>
+      <div className="text-center">
+        <p className="font-medium text-foreground text-sm">{count}</p>
+        <p className="text-muted-foreground text-xs">{month.substring(0, 3)}</p>
+      </div>
+    </Section>
+  );
+}
+
+const WrappedPage = () => {
+  const stats = WRAPPED_2025_STATS;
+  const maxMonthCount = Math.max(
+    ...stats.commitsByMonth.map((m) => m.count),
+    1
+  );
+  const randomMessage =
+    WITTY_MESSSAGES[Math.floor(Math.random() * WITTY_MESSSAGES.length)];
+
+  const COLORS = {
+    feat: 'bg-primary',
+    fix: 'bg-destructive',
+    refactor: 'bg-accent',
+    chore: 'bg-secondary',
+    other: 'bg-muted-foreground',
+  };
+
+  return (
+    <>
+      <Section className="gap-0">
+        <div className="mb-8 flex items-center gap-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-border bg-primary/10">
+            <SparklesIcon className="h-8 w-8 text-primary" />
+          </div>
+          <div>
+            <h1 className="font-bold text-4xl text-foreground">
+              Milind Wrapped 2025
+            </h1>
+            <p className="text-muted-foreground">
+              A year in review of code & creativity
+            </p>
+          </div>
+        </div>
+
+        <div className="my-6 rounded-lg border border-border bg-accent/5 p-4">
+          <p className="text-foreground-lighter text-sm">
+            <span className="font-semibold text-foreground">
+              {randomMessage.title}
+            </span>
+            <span className="mx-2">•</span>
+            {randomMessage.message}
+          </p>
+        </div>
+      </Section>
+
+      <Section delay={0.2}>
+        <h2 className="mb-4 font-bold text-foreground text-xl">The Numbers</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <StatCard
+            delay={0.25}
+            description="Pushed to git this year"
+            icon={GitCommitIcon}
+            title="Total Commits"
+            value={stats.totalCommits}
+          />
+          <StatCard
+            delay={0.3}
+            description="Fresh code written"
+            icon={Code2Icon}
+            title="Lines Added"
+            value={stats.linesAdded.toLocaleString()}
+          />
+          <StatCard
+            delay={0.35}
+            description="New things built"
+            icon={TrophyIcon}
+            title="Features Shipped"
+            value={stats.featCommits}
+          />
+          <StatCard
+            delay={0.4}
+            description="Total lines modified"
+            icon={FlameIcon}
+            title="Code Changes"
+            value={stats.totalChanges.toLocaleString()}
+          />
+        </div>
+      </Section>
+
+      <Section delay={0.5}>
+        <h2 className="mb-4 font-bold text-foreground text-xl">
+          Commit Activity by Month
+        </h2>
+        <div className="rounded-lg border border-border bg-card p-6">
+          <p className="mb-6 text-muted-foreground text-sm">
+            Most active month:{' '}
+            <span className="font-semibold text-foreground">
+              {stats.mostActiveMonth}
+            </span>{' '}
+            with{' '}
+            <span className="font-semibold text-foreground">
+              {Math.max(...stats.commitsByMonth.map((m) => m.count))} commits
+            </span>
+          </p>
+          <div className="grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-12">
+            {stats.commitsByMonth.map((month, index) => (
+              <MonthBar
+                count={month.count}
+                delay={0.55 + index * 0.05}
+                key={month.month}
+                maxCount={maxMonthCount}
+                month={month.month}
+              />
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      <Section delay={0.7}>
+        <h2 className="mb-4 font-bold text-foreground text-xl">
+          Commit Breakdown
+        </h2>
+        <div className="space-y-4 rounded-lg border border-border bg-card p-6">
+          <CommitTypeBar
+            color={COLORS.feat}
+            count={stats.featCommits}
+            delay={0.75}
+            total={stats.totalCommits}
+            type="features"
+          />
+          <CommitTypeBar
+            color={COLORS.fix}
+            count={stats.fixCommits}
+            delay={0.8}
+            total={stats.totalCommits}
+            type="fixes"
+          />
+          <CommitTypeBar
+            color={COLORS.refactor}
+            count={stats.refactorCommits}
+            delay={0.85}
+            total={stats.totalCommits}
+            type="refactors"
+          />
+          <CommitTypeBar
+            color={COLORS.chore}
+            count={stats.choreCommits}
+            delay={0.9}
+            total={stats.totalCommits}
+            type="chores"
+          />
+          <CommitTypeBar
+            color={COLORS.other}
+            count={stats.otherCommits}
+            delay={0.95}
+            total={stats.totalCommits}
+            type="other"
+          />
+        </div>
+      </Section>
+
+      <Section delay={1.1}>
+        <h2 className="mb-4 font-bold text-foreground text-xl">
+          Year Highlights
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {WRAPPED_HIGHLIGHTS.map((highlight, index) => {
+            const Icon = getHighlightIcon(highlight.icon);
+            return (
+              <Section
+                className="flex h-full flex-col rounded-lg border border-border bg-card p-5 transition-colors hover:bg-accent/5"
+                delay={1.15 + index * 0.05}
+                key={highlight.title}
+              >
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                  <Icon className="h-6 w-6 text-primary" />
+                </div>
+                <h3 className="mb-2 shrink-0 font-semibold text-foreground text-sm">
+                  {highlight.title}
+                </h3>
+                <p className="line-clamp-3 text-muted-foreground text-xs">
+                  {highlight.description}
+                </p>
+              </Section>
+            );
+          })}
+        </div>
+      </Section>
+
+      <Section delay={1.5}>
+        <h2 className="mb-4 font-bold text-foreground text-xl">Fun Facts</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
+            <p className="mb-2 shrink-0 text-muted-foreground text-xs uppercase">
+              Most Productive Day
+            </p>
+            <p className="shrink-0 font-semibold text-foreground text-lg">
+              {stats.mostActiveDate || 'N/A'}
+            </p>
+            <p className="mt-1 text-muted-foreground text-xs">
+              The day with most commits
+            </p>
+          </div>
+          <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
+            <p className="mb-2 shrink-0 text-muted-foreground text-xs uppercase">
+              Code Efficiency
+            </p>
+            <p className="shrink-0 font-semibold text-foreground text-lg">
+              {(
+                ((stats.linesAdded - stats.linesDeleted) /
+                  (stats.linesAdded || 1)) *
+                100
+              ).toFixed(1)}
+              %
+            </p>
+            <p className="mt-1 text-muted-foreground text-xs">
+              Net code growth rate
+            </p>
+          </div>
+          <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
+            <p className="mb-2 shrink-0 text-muted-foreground text-xs uppercase">
+              Avg. Commits/Day
+            </p>
+            <p className="shrink-0 font-semibold text-foreground text-lg">
+              {(stats.totalCommits / 365).toFixed(1)}
+            </p>
+            <p className="mt-1 text-muted-foreground text-xs">
+              Daily commitment level
+            </p>
+          </div>
+          <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
+            <p className="mb-2 shrink-0 text-muted-foreground text-xs uppercase">
+              Lines per Commit
+            </p>
+            <p className="shrink-0 font-semibold text-foreground text-lg">
+              {(stats.totalChanges / (stats.totalCommits || 1)).toFixed(0)}
+            </p>
+            <p className="mt-1 text-muted-foreground text-xs">
+              Average impact per commit
+            </p>
+          </div>
+        </div>
+      </Section>
+
+      <Section delay={1.7}>
+        <div className="rounded-lg border border-border bg-accent/5 p-6 text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <RocketIcon className="h-6 w-6 text-primary" />
+            <p className="font-bold text-foreground text-xl">
+              Here's to an even better 2026!
+            </p>
+            <RocketIcon className="h-6 w-6 text-primary" />
+          </div>
+          <p className="text-muted-foreground text-sm">
+            Keep building, keep shipping, keep growing
+          </p>
+        </div>
+      </Section>
+    </>
+  );
+};
+
+export default WrappedPage;

--- a/app/portfolio-stats-2025/page.tsx
+++ b/app/portfolio-stats-2025/page.tsx
@@ -1,16 +1,3 @@
-import {
-  BarChart3Icon,
-  Code2Icon,
-  FileTextIcon,
-  FlameIcon,
-  GitCommitIcon,
-  KeyboardIcon,
-  MusicIcon,
-  PaletteIcon,
-  RocketIcon,
-  SparklesIcon,
-  TrophyIcon,
-} from 'lucide-react';
 import type { Metadata } from 'next';
 import { Section } from '@/components/section';
 import { WRAPPED_2025_STATS, WRAPPED_HIGHLIGHTS } from '@/lib/data/wrapped';
@@ -18,58 +5,37 @@ import { createMetadata } from '@/lib/metadata';
 import { cn } from '@/lib/utils';
 
 export const metadata: Metadata = createMetadata({
-  title: 'Milind Wrapped 2025',
-  description: 'A year in review of Milind Mishra coding journey in 2025',
-  image: `/og?title=${encodeURIComponent('Milind Wrapped 2025')}&description=${encodeURIComponent('A year in review of 2025')}`,
+  title: 'Portfolio Stats 2025',
+  description: 'Git statistics and highlights from the portfolio repository in 2025',
+  image: `/og?title=${encodeURIComponent('Portfolio Stats 2025')}&description=${encodeURIComponent('Portfolio repository statistics for 2025')}`,
 });
 
 const WITTY_MESSSAGES = [
   {
-    title: 'Code Commit Champion',
-    message: 'More commits than some people have thoughts in a day!',
+    title: 'Portfolio Evolution',
+    message: 'Continuously improving and evolving the personal website.',
   },
   {
-    title: 'Feature Factory',
-    message: "Shipping features like it's a pizza delivery service.",
+    title: 'Iterative Development',
+    message: "Building better experiences, one commit at a time.",
   },
   {
-    title: 'Bug Slayer',
-    message: 'Fixing bugs with surgical precision (and some duct tape).',
+    title: 'Personal Project',
+    message: 'A space for learning, experimenting, and showcasing work.',
   },
   {
-    title: 'Full Stack Warrior',
-    message: "Frontend, backend, database - you name it, I've done it.",
+    title: 'Always Building',
+    message: 'Consistently adding features and refining the portfolio.',
   },
 ];
 
-function getHighlightIcon(iconName: string) {
-  switch (iconName) {
-    case 'palette':
-      return PaletteIcon;
-    case 'keyboard':
-      return KeyboardIcon;
-    case 'music':
-      return MusicIcon;
-    case 'chart':
-      return BarChart3Icon;
-    case 'file':
-      return FileTextIcon;
-    case 'sparkles':
-      return SparklesIcon;
-    default:
-      return SparklesIcon;
-  }
-}
-
 function StatCard({
-  icon: Icon,
   title,
   value,
   description,
   delay,
   className,
 }: {
-  icon: React.ElementType;
   title: string;
   value: string | number;
   description: string;
@@ -79,12 +45,6 @@ function StatCard({
   return (
     <Section className={cn('flex h-full flex-col', className)} delay={delay}>
       <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6 transition-colors hover:bg-accent/5">
-        <div className="mb-3 flex shrink-0 items-start justify-between">
-          <Icon className="h-5 w-5 text-muted-foreground" />
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
-            <Icon className="h-4 w-4 text-primary" />
-          </div>
-        </div>
         <h3 className="shrink-0 font-medium text-foreground-lighter text-xs uppercase tracking-wider">
           {title}
         </h3>
@@ -101,13 +61,11 @@ function CommitTypeBar({
   type,
   count,
   total,
-  color,
   delay,
 }: {
   type: string;
   count: number;
   total: number;
-  color: string;
   delay?: number;
 }) {
   const percentage = ((count / total) * 100).toFixed(1);
@@ -116,7 +74,7 @@ function CommitTypeBar({
     <Section className="space-y-2" delay={delay}>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <div className={cn('h-3 w-3 rounded-full', color)} />
+          <div className="h-3 w-3 rounded-full bg-primary" />
           <span className="font-medium text-foreground text-sm capitalize">
             {type}
           </span>
@@ -125,10 +83,7 @@ function CommitTypeBar({
       </div>
       <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
         <div
-          className={cn(
-            'h-full rounded-full transition-all duration-500',
-            color
-          )}
+          className="h-full rounded-full bg-primary transition-all duration-500"
           style={{ width: `${percentage}%` }}
         />
       </div>
@@ -154,13 +109,19 @@ function MonthBar({
   return (
     <Section className="flex flex-col items-center gap-2" delay={delay}>
       <div className="flex h-40 w-full items-end justify-center">
-        <div
-          className="w-full max-w-[3rem] rounded-t-lg bg-primary transition-all duration-500 hover:bg-primary/80"
-          style={{ height: `${height}%` }}
-        />
+        {count > 0 ? (
+          <div
+            className="w-full max-w-[3rem] rounded-t-lg bg-primary transition-all duration-500 hover:bg-primary/80"
+            style={{ height: `${height}%` }}
+          />
+        ) : (
+          <div className="w-full max-w-[3rem] border-t-2 border-dashed border-border" />
+        )}
       </div>
       <div className="text-center">
-        <p className="font-medium text-foreground text-sm">{count}</p>
+        <p className="font-medium text-foreground text-sm">
+          {count > 0 ? count : '-'}
+        </p>
         <p className="text-muted-foreground text-xs">{month.substring(0, 3)}</p>
       </div>
     </Section>
@@ -176,29 +137,16 @@ const WrappedPage = () => {
   const randomMessage =
     WITTY_MESSSAGES[Math.floor(Math.random() * WITTY_MESSSAGES.length)];
 
-  const COLORS = {
-    feat: 'bg-primary',
-    fix: 'bg-destructive',
-    refactor: 'bg-accent',
-    chore: 'bg-secondary',
-    other: 'bg-muted-foreground',
-  };
-
   return (
     <>
       <Section className="gap-0">
-        <div className="mb-8 flex items-center gap-4">
-          <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-border bg-primary/10">
-            <SparklesIcon className="h-8 w-8 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-bold text-4xl text-foreground">
-              Milind Wrapped 2025
-            </h1>
-            <p className="text-muted-foreground">
-              A year in review of code & creativity
-            </p>
-          </div>
+        <div className="mb-8">
+          <h1 className="font-bold text-4xl text-foreground">
+            Portfolio Stats 2025
+          </h1>
+          <p className="text-muted-foreground">
+            Git statistics and highlights from the portfolio repository
+          </p>
         </div>
 
         <div className="my-6 rounded-lg border border-border bg-accent/5 p-4">
@@ -217,29 +165,25 @@ const WrappedPage = () => {
         <div className="grid gap-4 sm:grid-cols-2">
           <StatCard
             delay={0.25}
-            description="Pushed to git this year"
-            icon={GitCommitIcon}
+            description="Commits to the portfolio repository"
             title="Total Commits"
             value={stats.totalCommits}
           />
           <StatCard
             delay={0.3}
-            description="Fresh code written"
-            icon={Code2Icon}
+            description="Lines added to the portfolio"
             title="Lines Added"
             value={stats.linesAdded.toLocaleString()}
           />
           <StatCard
             delay={0.35}
-            description="New things built"
-            icon={TrophyIcon}
+            description="New portfolio features shipped"
             title="Features Shipped"
             value={stats.featCommits}
           />
           <StatCard
             delay={0.4}
-            description="Total lines modified"
-            icon={FlameIcon}
+            description="Total lines changed in portfolio"
             title="Code Changes"
             value={stats.totalChanges.toLocaleString()}
           />
@@ -281,35 +225,30 @@ const WrappedPage = () => {
         </h2>
         <div className="space-y-4 rounded-lg border border-border bg-card p-6">
           <CommitTypeBar
-            color={COLORS.feat}
             count={stats.featCommits}
             delay={0.75}
             total={stats.totalCommits}
             type="features"
           />
           <CommitTypeBar
-            color={COLORS.fix}
             count={stats.fixCommits}
             delay={0.8}
             total={stats.totalCommits}
             type="fixes"
           />
           <CommitTypeBar
-            color={COLORS.refactor}
             count={stats.refactorCommits}
             delay={0.85}
             total={stats.totalCommits}
             type="refactors"
           />
           <CommitTypeBar
-            color={COLORS.chore}
             count={stats.choreCommits}
             delay={0.9}
             total={stats.totalCommits}
             type="chores"
           />
           <CommitTypeBar
-            color={COLORS.other}
             count={stats.otherCommits}
             delay={0.95}
             total={stats.totalCommits}
@@ -320,49 +259,43 @@ const WrappedPage = () => {
 
       <Section delay={1.1}>
         <h2 className="mb-4 font-bold text-foreground text-xl">
-          Year Highlights
+          Portfolio Highlights
         </h2>
         <div className="grid gap-4 sm:grid-cols-2">
-          {WRAPPED_HIGHLIGHTS.map((highlight, index) => {
-            const Icon = getHighlightIcon(highlight.icon);
-            return (
-              <Section
-                className="flex h-full flex-col rounded-lg border border-border bg-card p-5 transition-colors hover:bg-accent/5"
-                delay={1.15 + index * 0.05}
-                key={highlight.title}
-              >
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-                  <Icon className="h-6 w-6 text-primary" />
-                </div>
-                <h3 className="mb-2 shrink-0 font-semibold text-foreground text-sm">
-                  {highlight.title}
-                </h3>
-                <p className="line-clamp-3 text-muted-foreground text-xs">
-                  {highlight.description}
-                </p>
-              </Section>
-            );
-          })}
+          {WRAPPED_HIGHLIGHTS.map((highlight, index) => (
+            <Section
+              className="flex h-full flex-col rounded-lg border border-border bg-card p-5 transition-colors hover:bg-accent/5"
+              delay={1.15 + index * 0.05}
+              key={highlight.title}
+            >
+              <h3 className="mb-2 shrink-0 font-semibold text-foreground text-sm">
+                {highlight.title}
+              </h3>
+              <p className="line-clamp-3 text-muted-foreground text-xs">
+                {highlight.description}
+              </p>
+            </Section>
+          ))}
         </div>
       </Section>
 
       <Section delay={1.5}>
-        <h2 className="mb-4 font-bold text-foreground text-xl">Fun Facts</h2>
+        <h2 className="mb-4 font-bold text-foreground text-xl">Portfolio Insights</h2>
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
             <p className="mb-2 shrink-0 text-muted-foreground text-xs uppercase">
-              Most Productive Day
+              Most Active Day
             </p>
             <p className="shrink-0 font-semibold text-foreground text-lg">
               {stats.mostActiveDate || 'N/A'}
             </p>
             <p className="mt-1 text-muted-foreground text-xs">
-              The day with most commits
+              Day with the most portfolio commits
             </p>
           </div>
           <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
             <p className="mb-2 shrink-0 text-muted-foreground text-xs uppercase">
-              Code Efficiency
+              Code Growth
             </p>
             <p className="shrink-0 font-semibold text-foreground text-lg">
               {(
@@ -373,7 +306,7 @@ const WrappedPage = () => {
               %
             </p>
             <p className="mt-1 text-muted-foreground text-xs">
-              Net code growth rate
+              Net portfolio code growth rate
             </p>
           </div>
           <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
@@ -384,7 +317,7 @@ const WrappedPage = () => {
               {(stats.totalCommits / 365).toFixed(1)}
             </p>
             <p className="mt-1 text-muted-foreground text-xs">
-              Daily commitment level
+              Daily portfolio development pace
             </p>
           </div>
           <div className="flex h-full flex-col rounded-lg border border-border bg-card p-6">
@@ -395,7 +328,7 @@ const WrappedPage = () => {
               {(stats.totalChanges / (stats.totalCommits || 1)).toFixed(0)}
             </p>
             <p className="mt-1 text-muted-foreground text-xs">
-              Average impact per commit
+              Average changes per portfolio commit
             </p>
           </div>
         </div>
@@ -403,15 +336,11 @@ const WrappedPage = () => {
 
       <Section delay={1.7}>
         <div className="rounded-lg border border-border bg-accent/5 p-6 text-center">
-          <div className="mb-4 flex items-center justify-center gap-2">
-            <RocketIcon className="h-6 w-6 text-primary" />
-            <p className="font-bold text-foreground text-xl">
-              Here's to an even better 2026!
-            </p>
-            <RocketIcon className="h-6 w-6 text-primary" />
-          </div>
+          <p className="mb-4 font-bold text-foreground text-xl">
+            Here's to an even better portfolio in 2026!
+          </p>
           <p className="text-muted-foreground text-sm">
-            Keep building, keep shipping, keep growing
+            Keep building, keep shipping, keep improving
           </p>
         </div>
       </Section>

--- a/app/portfolio-stats-2025/page.tsx
+++ b/app/portfolio-stats-2025/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = createMetadata({
   image: `/og?title=${encodeURIComponent('Portfolio Stats 2025')}&description=${encodeURIComponent('Portfolio repository statistics for 2025')}`,
 });
 
-const WITTY_MESSSAGES = [
+const WITTY_MESSAGES = [
   {
     title: 'Portfolio Evolution',
     message: 'Continuously improving and evolving the personal website.',
@@ -68,7 +68,7 @@ function CommitTypeBar({
   total: number;
   delay?: number;
 }) {
-  const percentage = ((count / total) * 100).toFixed(1);
+  const percentageNumber = total > 0 ? (count / total) * 100 : 0;
 
   return (
     <Section className="space-y-2" delay={delay}>
@@ -84,10 +84,10 @@ function CommitTypeBar({
       <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
         <div
           className="h-full rounded-full bg-primary transition-all duration-500"
-          style={{ width: `${percentage}%` }}
+          style={{ width: `${percentageNumber.toFixed(1)}%` }}
         />
       </div>
-      <p className="text-muted-foreground text-xs">{percentage}% of total</p>
+      <p className="text-muted-foreground text-xs">{percentageNumber.toFixed(1)}% of total</p>
     </Section>
   );
 }
@@ -135,7 +135,7 @@ const WrappedPage = () => {
     1
   );
   const randomMessage =
-    WITTY_MESSSAGES[Math.floor(Math.random() * WITTY_MESSSAGES.length)];
+    WITTY_MESSAGES[Math.floor(Math.random() * WITTY_MESSAGES.length)];
 
   return (
     <>

--- a/lib/data/wrapped.ts
+++ b/lib/data/wrapped.ts
@@ -1,0 +1,252 @@
+import { execSync } from 'node:child_process';
+
+export type CommitType = 'feat' | 'fix' | 'refactor' | 'chore' | 'other';
+
+export type Commit = {
+  hash: string;
+  date: Date;
+  type: CommitType;
+  message: string;
+  shortHash: string;
+};
+
+export type MonthlyStats = {
+  month: string;
+  monthIndex: number;
+  year: number;
+  count: number;
+  commits: Commit[];
+};
+
+export type YearlyStats = {
+  totalCommits: number;
+  linesAdded: number;
+  linesDeleted: number;
+  totalChanges: number;
+  featCommits: number;
+  fixCommits: number;
+  refactorCommits: number;
+  choreCommits: number;
+  otherCommits: number;
+  mostActiveMonth: string;
+  mostActiveDate: string;
+  commitsByType: Record<CommitType, number>;
+  commitsByMonth: MonthlyStats[];
+};
+
+function getCommitType(message: string): CommitType {
+  const prefix = message.split(':')[0].toLowerCase();
+  if (prefix.startsWith('feat')) {
+    return 'feat';
+  }
+  if (prefix.startsWith('fix')) {
+    return 'fix';
+  }
+  if (prefix.startsWith('refactor')) {
+    return 'refactor';
+  }
+  if (prefix.startsWith('chore')) {
+    return 'chore';
+  }
+  return 'other';
+}
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+function getMonthName(month: number): string {
+  return MONTH_NAMES[month];
+}
+
+export function getYearlyStats(year: number): YearlyStats {
+  try {
+    const startDate = `${year}-01-01`;
+    const endDate = `${year}-12-31`;
+
+    const commitsOutput = execSync(
+      `git log --since="${startDate}" --until="${endDate}" --pretty=format:"%h|%ad|%s" --date=short`,
+      { encoding: 'utf-8' }
+    );
+
+    const statsOutput = execSync(
+      `git log --since="${startDate}" --until="${endDate}" --numstat --pretty=format:""`,
+      { encoding: 'utf-8' }
+    );
+
+    const commits: Commit[] = commitsOutput
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [hash, date, message] = line.split('|');
+        return {
+          hash,
+          shortHash: hash.substring(0, 7),
+          date: new Date(date),
+          type: getCommitType(message),
+          message,
+        };
+      });
+
+    let linesAdded = 0;
+    let linesDeleted = 0;
+
+    for (const line of statsOutput.split('\n')) {
+      const [added, deleted] = line.split('\t');
+      if (added && !added.startsWith('-')) {
+        linesAdded += Number.parseInt(added, 10) || 0;
+      }
+      if (deleted && !deleted.startsWith('-')) {
+        linesDeleted += Number.parseInt(deleted, 10) || 0;
+      }
+    }
+
+    const commitsByType: Record<CommitType, number> = {
+      feat: 0,
+      fix: 0,
+      refactor: 0,
+      chore: 0,
+      other: 0,
+    };
+
+    for (const commit of commits) {
+      commitsByType[commit.type] += 1;
+    }
+
+    const monthCounts = new Map<number, Commit[]>();
+
+    for (const commit of commits) {
+      const monthKey = commit.date.getMonth();
+      if (!monthCounts.has(monthKey)) {
+        monthCounts.set(monthKey, []);
+      }
+      monthCounts.get(monthKey)?.push(commit);
+    }
+
+    const commitsByMonth: MonthlyStats[] = Array.from(monthCounts.entries())
+      .map(([monthIndex, monthCommits]) => ({
+        month: getMonthName(monthIndex),
+        monthIndex,
+        year,
+        count: monthCommits.length,
+        commits: monthCommits,
+      }))
+      .sort((a, b) => a.monthIndex - b.monthIndex);
+
+    const mostActiveMonthObj = commitsByMonth.reduce((max, current) =>
+      current.count > max.count ? current : max
+    );
+
+    const dateCounts = new Map<string, number>();
+    for (const commit of commits) {
+      const dateKey = commit.date.toISOString().split('T')[0];
+      dateCounts.set(dateKey, (dateCounts.get(dateKey) || 0) + 1);
+    }
+
+    const mostActiveDate = Array.from(dateCounts.entries()).reduce(
+      (max, [date, count]) => (count > max.count ? { date, count } : max),
+      { date: '', count: 0 }
+    );
+
+    return {
+      totalCommits: commits.length,
+      linesAdded,
+      linesDeleted,
+      totalChanges: linesAdded + linesDeleted,
+      featCommits: commitsByType.feat,
+      fixCommits: commitsByType.fix,
+      refactorCommits: commitsByType.refactor,
+      choreCommits: commitsByType.chore,
+      otherCommits: commitsByType.other,
+      mostActiveMonth: `${mostActiveMonthObj.month} ${mostActiveMonthObj.year}`,
+      mostActiveDate: mostActiveDate.date,
+      commitsByType,
+      commitsByMonth,
+    };
+  } catch (_error) {
+    return {
+      totalCommits: 0,
+      linesAdded: 0,
+      linesDeleted: 0,
+      totalChanges: 0,
+      featCommits: 0,
+      fixCommits: 0,
+      refactorCommits: 0,
+      choreCommits: 0,
+      otherCommits: 0,
+      mostActiveMonth: '',
+      mostActiveDate: '',
+      commitsByType: {
+        feat: 0,
+        fix: 0,
+        refactor: 0,
+        chore: 0,
+        other: 0,
+      },
+      commitsByMonth: [],
+    };
+  }
+}
+
+export const WRAPPED_2025_STATS = getYearlyStats(2025);
+
+export type HighlightIcon =
+  | 'palette'
+  | 'keyboard'
+  | 'music'
+  | 'chart'
+  | 'file'
+  | 'sparkles';
+
+export type Highlight = {
+  title: string;
+  description: string;
+  icon: HighlightIcon;
+};
+
+export const WRAPPED_HIGHLIGHTS: Highlight[] = [
+  {
+    title: 'Portfolio Redesign',
+    description:
+      'Completely redesigned the portfolio with new animations and project showcase',
+    icon: 'palette',
+  },
+  {
+    title: 'Command Palette',
+    description:
+      'Added lightning-fast keyboard navigation with command palette',
+    icon: 'keyboard',
+  },
+  {
+    title: 'Spotify Integration',
+    description: 'Live now playing and top tracks displayed on the homepage',
+    icon: 'music',
+  },
+  {
+    title: 'Wakatime Stats',
+    description: 'Integrated real-time coding statistics and insights',
+    icon: 'chart',
+  },
+  {
+    title: 'Guestbook',
+    description: 'Interactive guestbook with real-time updates',
+    icon: 'file',
+  },
+  {
+    title: 'View Transitions',
+    description: 'Smooth page transitions using the View Transition API',
+    icon: 'sparkles',
+  },
+];

--- a/lib/data/wrapped.ts
+++ b/lib/data/wrapped.ts
@@ -1,5 +1,3 @@
-import { execSync } from 'node:child_process';
-
 export type CommitType = 'feat' | 'fix' | 'refactor' | 'chore' | 'other';
 
 export type Commit = {
@@ -34,186 +32,116 @@ export type YearlyStats = {
   commitsByMonth: MonthlyStats[];
 };
 
-function getCommitType(message: string): CommitType {
-  const prefix = message.split(':')[0].toLowerCase();
-  if (prefix.startsWith('feat')) {
-    return 'feat';
-  }
-  if (prefix.startsWith('fix')) {
-    return 'fix';
-  }
-  if (prefix.startsWith('refactor')) {
-    return 'refactor';
-  }
-  if (prefix.startsWith('chore')) {
-    return 'chore';
-  }
-  return 'other';
-}
-
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
-
-function getMonthName(month: number): string {
-  return MONTH_NAMES[month];
-}
-
-export function getYearlyStats(year: number): YearlyStats {
-  try {
-    const startDate = `${year}-01-01`;
-    const endDate = `${year}-12-31`;
-
-    const commitsOutput = execSync(
-      `git log --since="${startDate}" --until="${endDate}" --pretty=format:"%h|%ad|%s" --date=short`,
-      { encoding: 'utf-8' }
-    );
-
-    const statsOutput = execSync(
-      `git log --since="${startDate}" --until="${endDate}" --numstat --pretty=format:""`,
-      { encoding: 'utf-8' }
-    );
-
-    const commits: Commit[] = commitsOutput
-      .trim()
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => {
-        const [hash, date, message] = line.split('|');
-        return {
-          hash,
-          shortHash: hash.substring(0, 7),
-          date: new Date(date),
-          type: getCommitType(message),
-          message,
-        };
-      });
-
-    let linesAdded = 0;
-    let linesDeleted = 0;
-
-    for (const line of statsOutput.split('\n')) {
-      const [added, deleted] = line.split('\t');
-      if (added && !added.startsWith('-')) {
-        linesAdded += Number.parseInt(added, 10) || 0;
-      }
-      if (deleted && !deleted.startsWith('-')) {
-        linesDeleted += Number.parseInt(deleted, 10) || 0;
-      }
-    }
-
-    const commitsByType: Record<CommitType, number> = {
-      feat: 0,
-      fix: 0,
-      refactor: 0,
-      chore: 0,
-      other: 0,
-    };
-
-    for (const commit of commits) {
-      commitsByType[commit.type] += 1;
-    }
-
-    const monthCounts = new Map<number, Commit[]>();
-
-    for (const commit of commits) {
-      const monthKey = commit.date.getMonth();
-      if (!monthCounts.has(monthKey)) {
-        monthCounts.set(monthKey, []);
-      }
-      monthCounts.get(monthKey)?.push(commit);
-    }
-
-    const commitsByMonth: MonthlyStats[] = Array.from(monthCounts.entries())
-      .map(([monthIndex, monthCommits]) => ({
-        month: getMonthName(monthIndex),
-        monthIndex,
-        year,
-        count: monthCommits.length,
-        commits: monthCommits,
-      }))
-      .sort((a, b) => a.monthIndex - b.monthIndex);
-
-    const mostActiveMonthObj = commitsByMonth.reduce((max, current) =>
-      current.count > max.count ? current : max
-    );
-
-    const dateCounts = new Map<string, number>();
-    for (const commit of commits) {
-      const dateKey = commit.date.toISOString().split('T')[0];
-      dateCounts.set(dateKey, (dateCounts.get(dateKey) || 0) + 1);
-    }
-
-    const mostActiveDate = Array.from(dateCounts.entries()).reduce(
-      (max, [date, count]) => (count > max.count ? { date, count } : max),
-      { date: '', count: 0 }
-    );
-
-    return {
-      totalCommits: commits.length,
-      linesAdded,
-      linesDeleted,
-      totalChanges: linesAdded + linesDeleted,
-      featCommits: commitsByType.feat,
-      fixCommits: commitsByType.fix,
-      refactorCommits: commitsByType.refactor,
-      choreCommits: commitsByType.chore,
-      otherCommits: commitsByType.other,
-      mostActiveMonth: `${mostActiveMonthObj.month} ${mostActiveMonthObj.year}`,
-      mostActiveDate: mostActiveDate.date,
-      commitsByType,
-      commitsByMonth,
-    };
-  } catch (_error) {
-    return {
-      totalCommits: 0,
-      linesAdded: 0,
-      linesDeleted: 0,
-      totalChanges: 0,
-      featCommits: 0,
-      fixCommits: 0,
-      refactorCommits: 0,
-      choreCommits: 0,
-      otherCommits: 0,
-      mostActiveMonth: '',
-      mostActiveDate: '',
-      commitsByType: {
-        feat: 0,
-        fix: 0,
-        refactor: 0,
-        chore: 0,
-        other: 0,
-      },
-      commitsByMonth: [],
-    };
-  }
-}
-
-export const WRAPPED_2025_STATS = getYearlyStats(2025);
-
-export type HighlightIcon =
-  | 'palette'
-  | 'keyboard'
-  | 'music'
-  | 'chart'
-  | 'file'
-  | 'sparkles';
+export const WRAPPED_2025_STATS: YearlyStats = {
+  totalCommits: 232,
+  linesAdded: 65466,
+  linesDeleted: 29005,
+  totalChanges: 94471,
+  featCommits: 193,
+  fixCommits: 16,
+  refactorCommits: 5,
+  choreCommits: 4,
+  otherCommits: 14,
+  mostActiveMonth: 'August 2025',
+  mostActiveDate: '2025-11-29',
+  commitsByType: {
+    feat: 193,
+    fix: 16,
+    refactor: 5,
+    chore: 4,
+    other: 14,
+  },
+  commitsByMonth: [
+    {
+      month: 'January',
+      monthIndex: 0,
+      year: 2025,
+      count: 0,
+      commits: [],
+    },
+    {
+      month: 'February',
+      monthIndex: 1,
+      year: 2025,
+      count: 0,
+      commits: [],
+    },
+    {
+      month: 'March',
+      monthIndex: 2,
+      year: 2025,
+      count: 0,
+      commits: [],
+    },
+    {
+      month: 'April',
+      monthIndex: 3,
+      year: 2025,
+      count: 0,
+      commits: [],
+    },
+    {
+      month: 'May',
+      monthIndex: 4,
+      year: 2025,
+      count: 0,
+      commits: [],
+    },
+    {
+      month: 'June',
+      monthIndex: 5,
+      year: 2025,
+      count: 14,
+      commits: [],
+    },
+    {
+      month: 'July',
+      monthIndex: 6,
+      year: 2025,
+      count: 68,
+      commits: [],
+    },
+    {
+      month: 'August',
+      monthIndex: 7,
+      year: 2025,
+      count: 96,
+      commits: [],
+    },
+    {
+      month: 'September',
+      monthIndex: 8,
+      year: 2025,
+      count: 8,
+      commits: [],
+    },
+    {
+      month: 'October',
+      monthIndex: 9,
+      year: 2025,
+      count: 2,
+      commits: [],
+    },
+    {
+      month: 'November',
+      monthIndex: 10,
+      year: 2025,
+      count: 29,
+      commits: [],
+    },
+    {
+      month: 'December',
+      monthIndex: 11,
+      year: 2025,
+      count: 15,
+      commits: [],
+    },
+  ],
+};
 
 export type Highlight = {
   title: string;
   description: string;
-  icon: HighlightIcon;
 };
 
 export const WRAPPED_HIGHLIGHTS: Highlight[] = [
@@ -221,32 +149,26 @@ export const WRAPPED_HIGHLIGHTS: Highlight[] = [
     title: 'Portfolio Redesign',
     description:
       'Completely redesigned the portfolio with new animations and project showcase',
-    icon: 'palette',
   },
   {
     title: 'Command Palette',
     description:
       'Added lightning-fast keyboard navigation with command palette',
-    icon: 'keyboard',
   },
   {
     title: 'Spotify Integration',
     description: 'Live now playing and top tracks displayed on the homepage',
-    icon: 'music',
   },
   {
     title: 'Wakatime Stats',
     description: 'Integrated real-time coding statistics and insights',
-    icon: 'chart',
   },
   {
     title: 'Guestbook',
     description: 'Interactive guestbook with real-time updates',
-    icon: 'file',
   },
   {
     title: 'View Transitions',
     description: 'Smooth page transitions using the View Transition API',
-    icon: 'sparkles',
   },
 ];


### PR DESCRIPTION
<img width="700" height="923" alt="image" src="https://github.com/user-attachments/assets/eca2b1ef-d7d6-41f3-b1a5-bab8e3de61d8" />

## Summary
- Add new portfolio stats page for 2025
- Display git statistics and insights from the portfolio repository
- Include commit activity, breakdown by type, and highlights

## Changes
- New page at `/portfolio-stats-2025`
- Data structure for wrapped statistics
- Visual components for stat cards, commit bars, and monthly activity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Portfolio Stats 2025" dashboard with an intro, celebratory close, and randomized witty message.
  * Visual KPI grid showing totals (commits, lines added, features shipped, code changes).
  * Monthly commit activity charts and stacked commit-type breakdowns (feat, fix, refactor, chore, other).
  * Portfolio Highlights and Insights sections with curated project highlights and key computed metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->